### PR TITLE
Alter talk

### DIFF
--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -46,8 +46,7 @@ module Pandorabots
         succeed_compilation?(response)
       end
 
-      def talk(app_id, botname, input, client_name, sessionid: '', reset: false,
-               trace: false, recent: false, user_key:)
+      def talk(app_id, botname, input, client_name, user_key:)
         request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}&user_key=#{user_key}"
         post = Net::HTTP::Post.new(URI.escape(request_uri))
         response = https.request(post)

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -63,7 +63,7 @@ module Pandorabots
         uri = URI(BASE_URL)
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
-        @@https || = https
+        @@https ||= https
       end
 
       def filename(file)

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -46,7 +46,7 @@ module Pandorabots
         succeed_compilation?(response)
       end
 
-      def talk(app_id, botname, input, client_name, sessionid: '', reset: false,
+      def talk(app_id, botname, input, client_name: '', sessionid: '', reset: false,
                trace: false, recent: false, user_key:)
         request_uri = "/atalk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -1,5 +1,5 @@
 require 'pandorabots/version'
-require 'net/http/persistent'
+require 'net/https'
 require 'json'
 
 module Pandorabots
@@ -46,14 +46,13 @@ module Pandorabots
         succeed_compilation?(response)
       end
 
-      def talk(app_id, botname, input, client_name: '', sessionid: '', reset: false,
+      def talk(app_id, botname, input, client_name, sessionid: '', reset: false,
                trace: false, recent: false, user_key:)
-        request_uri = "/atalk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
-                      "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
-                      "&recent=#{recent}&user_key=#{user_key}"
-        post_uri = URI(BASE_URL + request_uri)
+        request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}&user_key=#{user_key}"
+                      # "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \ "&recent=#{recent}
+        # post_uri = URI(BASE_URL + request_uri), post_uri,
         post = Net::HTTP::Post.new(URI.escape(request_uri))
-        response = https.request(post_uri, post)
+        response = https.request(post)
         response_json = JSON.parse(response.body) if succeed_talk?(response)
         response_json
         # TalkResult.new(response.body) if succeed_talk?(response)
@@ -64,10 +63,9 @@ module Pandorabots
       end
 
       def set_https
-        # uri = URI(BASE_URL)
-        # (uri.host, uri.port)
-        vhttps = Net::HTTP::Persistent.new 'pb-ruby'
-        # vhttps.use_ssl = true
+        uri = URI(BASE_URL)
+        vhttps = Net::HTTP.new(uri.host, uri.port)
+        vhttps.use_ssl = true
         vhttps
       end
 

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -62,8 +62,9 @@ module Pandorabots
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
         @@https ||= https
+        @@https
       end
-      
+
       private
 
 

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -59,6 +59,7 @@ module Pandorabots
       private
 
       def https
+        return https if https
         uri = URI(BASE_URL)
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -1,5 +1,5 @@
 require 'pandorabots/version'
-require 'net/https'
+require 'net/http/persistent'
 require 'json'
 
 module Pandorabots
@@ -51,8 +51,9 @@ module Pandorabots
         request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
                       "&recent=#{recent}&user_key=#{user_key}"
+        post_uri = URI(BASE_URL + request_uri)
         post = Net::HTTP::Post.new(URI.escape(request_uri))
-        response = https.request(post)
+        response = https.request(post_uri, post)
         response_json = JSON.parse(response.body) if succeed_talk?(response)
         response_json
         # TalkResult.new(response.body) if succeed_talk?(response)
@@ -63,9 +64,10 @@ module Pandorabots
       end
 
       def set_https
-        uri = URI(BASE_URL)
-        vhttps = Net::HTTP.new(uri.host, uri.port)
-        vhttps.use_ssl = true
+        # uri = URI(BASE_URL)
+        # (uri.host, uri.port)
+        vhttps = Net::HTTP::Persistent.new 'pb-ruby'
+        # vhttps.use_ssl = true
         vhttps
       end
 

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -1,5 +1,5 @@
 require 'pandorabots/version'
-require 'net/https'
+require 'net/https/persistent'
 require 'json'
 
 module Pandorabots

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -45,7 +45,7 @@ module Pandorabots
       end
 
       def talk(app_id, botname, input, client_name, sessionid: '', reset: false,
-               trace: false, recent: true, user_key:)
+               trace: false, recent: false, user_key:)
         request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
                       "&user_key=#{user_key}"

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -58,8 +58,7 @@ module Pandorabots
 
       private
 
-      def https
-        return https if https
+      def https 
         uri = URI(BASE_URL)
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -64,8 +64,9 @@ module Pandorabots
 
       def set_https
         uri = URI(BASE_URL)
-        set_https = Net::HTTP.new(uri.host, uri.port)
-        set_https.use_ssl = true
+        vhttps = Net::HTTP.new(uri.host, uri.port)
+        vhttps.use_ssl = true
+        vhttps
       end
 
       private

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -49,13 +49,10 @@ module Pandorabots
       def talk(app_id, botname, input, client_name, sessionid: '', reset: false,
                trace: false, recent: false, user_key:)
         request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}&user_key=#{user_key}"
-                      # "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \ "&recent=#{recent}
-        # post_uri = URI(BASE_URL + request_uri), post_uri,
         post = Net::HTTP::Post.new(URI.escape(request_uri))
         response = https.request(post)
         response_json = JSON.parse(response.body) if succeed_talk?(response)
         response_json
-        # TalkResult.new(response.body) if succeed_talk?(response)
       end
 
       def https
@@ -70,7 +67,6 @@ module Pandorabots
       end
 
       private
-
 
       def filename(file)
         File.basename(file, '.*')

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -51,7 +51,9 @@ module Pandorabots
                       "&recent=#{recent}&user_key=#{user_key}"
         post = Net::HTTP::Post.new(URI.escape(request_uri))
         response = https.request(post)
-        TalkResult.new(response.body) if succeed_talk?(response)
+        response_json = JSON.parse(response.body) if succeed_talk?(response)
+        response_json
+        # TalkResult.new(response.body) if succeed_talk?(response)
       end
 
       private

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -49,7 +49,8 @@ module Pandorabots
         request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
                       "&recent=#{recent}&user_key=#{user_key}"
-        post = Net::HTTP::Post.new(URI.escape(request_uri))
+        uri = URI(BASE_URL)
+        post = Net::HTTP::Post.new(uri + URI.escape(request_uri))
         response = https.request(post)
         response_json = JSON.parse(response.body) if succeed_talk?(response)
         response_json
@@ -59,8 +60,9 @@ module Pandorabots
       private
 
       def https
-        uri = URI(BASE_URL)
-        https = Net::HTTP::Persistent.new(uri.host, uri.port)
+
+        # (uri.host, uri.port)
+        https = Net::HTTP::Persistent.new 'pb-ruby'
         https.use_ssl = true
         https
       end

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -1,5 +1,5 @@
 require 'pandorabots/version'
-require 'net/https/persistent'
+require 'net/http/persistent'
 require 'json'
 
 module Pandorabots

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -61,7 +61,7 @@ module Pandorabots
 
       def set_https
         uri = URI(BASE_URL)
-        https = Net::HTTP.new(uri.host, uri.port))
+        https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
         https
       end

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -57,14 +57,15 @@ module Pandorabots
         # TalkResult.new(response.body) if succeed_talk?(response)
       end
 
-      private
-
       def self.https
         uri = URI(BASE_URL)
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
         @@https ||= https
       end
+      
+      private
+
 
       def filename(file)
         File.basename(file, '.*')

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -48,7 +48,7 @@ module Pandorabots
                trace: false, recent: false, user_key:)
         request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
-                      "&user_key=#{user_key}"
+                      "&recent=#{recent}&user_key=#{user_key}"
         post = Net::HTTP::Post.new(URI.escape(request_uri))
         response = https.request(post)
         TalkResult.new(response.body) if succeed_talk?(response)

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -4,9 +4,8 @@ require 'json'
 
 module Pandorabots
   class API
-    @@https
+
     class << self
-      attr_accessor :https
 
       BASE_URL = 'https://aiaas.pandorabots.com'
       FILE_KIND = {
@@ -14,28 +13,17 @@ module Pandorabots
         properties: 'properties', pdefaults: 'pdefaults'
       }
 
-      def get_https
-        @@https
-      end
-
-      def set_https
-        uri = URI(BASE_URL)
-        https = Net::HTTP.new(uri.host, uri.port)
-        https.use_ssl = true
-        self.https = https  
-      end
-
       def create_bot(app_id, botname, user_key:)
         request_uri = "/bot/#{app_id}/#{botname}?user_key=#{user_key}"
         put = Net::HTTP::Put.new(URI.escape(request_uri))
-        response = @@https.request(put)
+        response = https.request(put)
         succeed_creation?(response)
       end
 
       def delete_bot(app_id, botname, user_key:)
         request_uri = "/bot/#{app_id}/#{botname}?user_key=#{user_key}"
         delete = Net::HTTP::Delete.new(URI.escape(request_uri))
-        response = @@https.request(delete)
+        response = https.request(delete)
         succeed_deletion?(response)
       end
 
@@ -47,14 +35,14 @@ module Pandorabots
                                       filename, user_key)
         put = Net::HTTP::Put.new(URI.escape(request_uri))
         put.body = file.read
-        response = @@https.request(put)
+        response = https.request(put)
         succeed_upload?(response)
       end
 
       def compile_bot(app_id, botname, user_key:)
         request_uri = "/bot/#{app_id}/#{botname}/verify?user_key=#{user_key}"
         get = Net::HTTP::Get.new(URI.escape(request_uri))
-        response = @@https.request(get)
+        response = https.request(get)
         succeed_compilation?(response)
       end
 
@@ -64,10 +52,17 @@ module Pandorabots
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
                       "&recent=#{recent}&user_key=#{user_key}"
         post = Net::HTTP::Post.new(URI.escape(request_uri))
-        response = @@https.request(post)
+        response = https.request(post)
         response_json = JSON.parse(response.body) if succeed_talk?(response)
         response_json
         # TalkResult.new(response.body) if succeed_talk?(response)
+      end
+
+      def https
+        uri = URI(BASE_URL)
+        set_https = Net::HTTP.new(uri.host, uri.port)
+        set_https.use_ssl = true
+        @https ||= set_https
       end
 
       private

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -49,9 +49,9 @@ module Pandorabots
         request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
                       "&recent=#{recent}&user_key=#{user_key}"
-        uri = URI(BASE_URL)
-        post = Net::HTTP::Post.new(uri + URI.escape(request_uri))
-        response = https.request(post)
+        post_uri = URI(BASE_URL) + URI.escape(request_uri)
+        post = Net::HTTP::Post.new(URI.escape(request_uri))
+        response = https.request(post_uri, post)
         response_json = JSON.parse(response.body) if succeed_talk?(response)
         response_json
         # TalkResult.new(response.body) if succeed_talk?(response)

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -63,7 +63,7 @@ module Pandorabots
 
         # (uri.host, uri.port)
         https = Net::HTTP::Persistent.new 'pb-ruby'
-        https.use_ssl = true
+        # https.use_ssl = true
         https
       end
 

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -59,10 +59,13 @@ module Pandorabots
       end
 
       def https
+        @https ||= set_https
+      end
+
+      def set_https
         uri = URI(BASE_URL)
         set_https = Net::HTTP.new(uri.host, uri.port)
         set_https.use_ssl = true
-        @https ||= set_https
       end
 
       private

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -5,7 +5,7 @@ require 'json'
 module Pandorabots
   class API
     class << self
-      @@https ||= set_https
+      @@https
       BASE_URL = 'https://aiaas.pandorabots.com'
       FILE_KIND = {
         aiml: 'file', set: 'set', map: 'map', substitution: 'substitution',
@@ -59,11 +59,11 @@ module Pandorabots
 
       private
 
-      def set_https
+      def self.https
         uri = URI(BASE_URL)
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
-        https
+        @@https || = https
       end
 
       def filename(file)

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -4,13 +4,26 @@ require 'json'
 
 module Pandorabots
   class API
+    @@https
     class << self
-      @@https
+      attr_accessor :https
+
       BASE_URL = 'https://aiaas.pandorabots.com'
       FILE_KIND = {
         aiml: 'file', set: 'set', map: 'map', substitution: 'substitution',
         properties: 'properties', pdefaults: 'pdefaults'
       }
+
+      def get_https
+        @@https
+      end
+
+      def set_https
+        uri = URI(BASE_URL)
+        https = Net::HTTP.new(uri.host, uri.port)
+        https.use_ssl = true
+        self.https = https  
+      end
 
       def create_bot(app_id, botname, user_key:)
         request_uri = "/bot/#{app_id}/#{botname}?user_key=#{user_key}"
@@ -55,14 +68,6 @@ module Pandorabots
         response_json = JSON.parse(response.body) if succeed_talk?(response)
         response_json
         # TalkResult.new(response.body) if succeed_talk?(response)
-      end
-
-      def self.https
-        uri = URI(BASE_URL)
-        https = Net::HTTP.new(uri.host, uri.port)
-        https.use_ssl = true
-        @@https ||= https
-        @@https
       end
 
       private

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -60,7 +60,7 @@ module Pandorabots
 
       def https
         uri = URI(BASE_URL)
-        https = Net::HTTP.Persistent.new(uri.host, uri.port)
+        https = Net::HTTP::Persistent.new(uri.host, uri.port)
         https.use_ssl = true
         https
       end

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -44,9 +44,9 @@ module Pandorabots
         succeed_compilation?(response)
       end
 
-      def talk(app_id, botname, input, sessionid: '', reset: false,
+      def talk(app_id, botname, input, client_name, sessionid: '', reset: false,
                trace: false, recent: true, user_key:)
-        request_uri = "/talk/#{app_id}/#{botname}?input=#{input}" \
+        request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
                       "&user_key=#{user_key}"
         post = Net::HTTP::Post.new(URI.escape(request_uri))

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -48,7 +48,7 @@ module Pandorabots
 
       def talk(app_id, botname, input, client_name, sessionid: '', reset: false,
                trace: false, recent: false, user_key:)
-        request_uri = "/talk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
+        request_uri = "/atalk/#{app_id}/#{botname}?input=#{input}&client_name=#{client_name}" \
                       "&sessionid=#{sessionid}&reset=#{reset}&trace=#{trace}" \
                       "&recent=#{recent}&user_key=#{user_key}"
         post_uri = URI(BASE_URL + request_uri)

--- a/lib/pandorabots.rb
+++ b/lib/pandorabots.rb
@@ -58,9 +58,9 @@ module Pandorabots
 
       private
 
-      def https 
+      def https
         uri = URI(BASE_URL)
-        https = Net::HTTP.new(uri.host, uri.port)
+        https = Net::HTTP.Persistent.new(uri.host, uri.port)
         https.use_ssl = true
         https
       end


### PR DESCRIPTION
I changed talk method, got rid of all the extra unused variables in request_uri string (which were causing the bot to not retain conversation predicates and information, the only necessary input variables are now app_id, botname, input, client_name, and user_key), also cleaned up https method so that a new call to Net::HTTP is only called if https isn't set, and got rid of call for new TalkResult object as this was slowing down responses.
